### PR TITLE
refactor research briefs' single-item lists

### DIFF
--- a/research/research_htmls/Ep1.html
+++ b/research/research_htmls/Ep1.html
@@ -117,9 +117,7 @@
         <div class="subsection-container fade-in visible">
             <h2 class="subsection-title">Takeaways for Episode Production</h2>
             <h4>Narrative hooks</h4>
-            <ul class="manifesto-text">
-                <li>Open with a vivid sensory moment: a Spartan boy being led away; a Maasai shaving rite; a youth alone on a vision quest. Emphasize emotional weight and finality.</li>
-            </ul>
+            <p class="manifesto-text">Open with a vivid sensory moment: a Spartan boy being led away; a Maasai shaving rite; a youth alone on a vision quest. Emphasize emotional weight and finality.</p>
             <h4>Guiding questions</h4>
             <ul class="manifesto-text">
                 <li>What aspects of the "childhood self" must be intentionally left behind to become an adult?</li>

--- a/research/research_htmls/Ep2.html
+++ b/research/research_htmls/Ep2.html
@@ -95,13 +95,9 @@
         <div class="subsection-container fade-in visible">
             <h2 class="subsection-title">Takeaways for Episode Production</h2>
             <h4>Narrative hook opportunities</h4>
-            <ul class="manifesto-text">
-                <li>Begin with visceral vignettes like the Maasai circumcision or the Sateré-Mawé bullet ant ritual.</li>
-            </ul>
+            <p class="manifesto-text">Begin with visceral vignettes like the Maasai circumcision or the Sateré-Mawé bullet ant ritual.</p>
             <h4>Big questions</h4>
-            <ul class="manifesto-text">
-                <li>In a world without formal rites, how do we know when we've become adults? Can we create new rites today?</li>
-            </ul>
+            <p class="manifesto-text">In a world without formal rites, how do we know when we've become adults? Can we create new rites today?</p>
             <p class="manifesto-text">Possible bridge: transition to discussions of modern resilience psychology or role of elders.</p>
         </div>
 

--- a/research/research_htmls/Ep3.html
+++ b/research/research_htmls/Ep3.html
@@ -77,13 +77,9 @@
         <div class="subsection-container fade-in visible">
             <h2 class="subsection-title">Takeaways for Episode Production</h2>
             <h4>Narrative hook opportunities</h4>
-            <ul class="manifesto-text">
-                <li>Open with a vivid initiation story, such as a Maasai warrior facing a lion or a youth on a vision quest.</li>
-            </ul>
+            <p class="manifesto-text">Open with a vivid initiation story, such as a Maasai warrior facing a lion or a youth on a vision quest.</p>
             <h4>Big questions</h4>
-            <ul class="manifesto-text">
-                <li>What initiations do we experience today, and how do we mark them without formal rites?</li>
-            </ul>
+            <p class="manifesto-text">What initiations do we experience today, and how do we mark them without formal rites?</p>
             <p class="manifesto-text">Possible bridge: explore modern creations of new rites or impacts of failed initiations.</p>
         </div>
 

--- a/research/research_htmls/Ep4.html
+++ b/research/research_htmls/Ep4.html
@@ -77,13 +77,9 @@
         <div class="subsection-container fade-in visible">
             <h2 class="subsection-title">Takeaways for Episode Production</h2>
             <h4>Narrative hook opportunities</h4>
-            <ul class="manifesto-text">
-                <li>Open with the story of a Spartan in the Krypteia or an Aboriginal youth on walkabout, contrasted with a modern teen facing a rock wall.</li>
-            </ul>
+            <p class="manifesto-text">Open with the story of a Spartan in the Krypteia or an Aboriginal youth on walkabout, contrasted with a modern teen facing a rock wall.</p>
             <h4>Big questions</h4>
-            <ul class="manifesto-text">
-                <li>Have we deprived youth of necessary challenges? How can we create meaningful rites today?</li>
-            </ul>
+            <p class="manifesto-text">Have we deprived youth of necessary challenges? How can we create meaningful rites today?</p>
             <p class="manifesto-text">Possible bridge: exploring post-traumatic growth and unchosen ordeals.</p>
         </div>
 


### PR DESCRIPTION
## Summary
- convert narrative-hook single-item lists to paragraphs in research briefs
- simplify episode question sections to text for consistent styling

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1ba8ab08c8323b6b59c069a28ae6e