### PR TITLE
Align episodes 2-4 research briefs with latest layout

### DIFF
--- a/research/research_htmls/Ep2.html
+++ b/research/research_htmls/Ep2.html
@@ -45,16 +45,36 @@
 
         <div class="subsection-container fade-in visible">
             <h2 class="subsection-title">Historical &amp; Cultural Context</h2>
-            <h3>Key Traditions</h3>
-            <ul class="manifesto-text">
-                <li><strong>Maasai (East Africa):</strong> The <em>Emurata</em> circumcision ceremony marks the transition to warriorhood.</li>
-                <li><strong>Okiek (Kenya):</strong> The <em>Tumdo</em> initiation involves seclusion and instruction in the forest.</li>
-                <li><strong>Sateré-Mawé (Amazon):</strong> The Tucandeira ritual uses bullet ant gloves repeated over years.</li>
-                <li><strong>Aboriginal Australians:</strong> Rites such as the <em>Bora</em> and walkabouts connect youths to Dreaming and ancestral law.</li>
-                <li><strong>Spartans (Ancient Greece):</strong> The <em>Agōgē</em> was a state-run program beginning at age seven.</li>
-                <li><strong>Norse (Viking Age):</strong> Wilderness survival and symbolic transformation into animal-like warriors.</li>
-                <li><strong>Celts (Iron Age Europe):</strong> Legendary trials like those of the Fianna tested endurance and intellect.</li>
-            </ul>
+            <div class="episodes-grid fade-in visible">
+                <div class="episode-card">
+                    <h3>Maasai (East Africa)</h3>
+                    <p class="hook">The <em>Emurata</em> circumcision ceremony marks the transition to warriorhood.</p>
+                </div>
+                <div class="episode-card">
+                    <h3>Okiek (Kenya)</h3>
+                    <p class="hook">The <em>Tumdo</em> initiation involves seclusion and instruction in the forest.</p>
+                </div>
+                <div class="episode-card">
+                    <h3>Sateré-Mawé (Amazon)</h3>
+                    <p class="hook">The Tucandeira ritual uses bullet ant gloves repeated over years.</p>
+                </div>
+                <div class="episode-card">
+                    <h3>Aboriginal Australians</h3>
+                    <p class="hook">Rites such as the <em>Bora</em> and walkabouts connect youths to Dreaming and ancestral law.</p>
+                </div>
+                <div class="episode-card">
+                    <h3>Spartans (Ancient Greece)</h3>
+                    <p class="hook">The <em>Agōgē</em> was a state-run program beginning at age seven.</p>
+                </div>
+                <div class="episode-card">
+                    <h3>Norse (Viking Age)</h3>
+                    <p class="hook">Wilderness survival and symbolic transformation into animal-like warriors.</p>
+                </div>
+                <div class="episode-card">
+                    <h3>Celts (Iron Age Europe)</h3>
+                    <p class="hook">Legendary trials like those of the Fianna tested endurance and intellect.</p>
+                </div>
+            </div>
             <h3>Narrative Anecdotes</h3>
             <ul class="manifesto-text">
                 <li>A Maasai boy endures circumcision without flinching as his mother celebrates his symbolic rebirth.</li>
@@ -66,12 +86,24 @@
 
         <div class="subsection-container fade-in visible">
             <h2 class="subsection-title">Psychological Functions</h2>
-            <ul class="core-pillars-grid">
-                <li class="pillar-card"><h3>Identity Formation</h3><p>Rites create a dramatic break from childhood identity and confer adult status, often described as symbolic death and rebirth.</p></li>
-                <li class="pillar-card"><h3>Resilience</h3><p>Enduring pain or hardship in ritual context teaches initiates they can withstand suffering, building lasting fortitude.</p></li>
-                <li class="pillar-card"><h3>Belonging</h3><p>Shared ordeals forge intense bonds and affirm membership in the adult community.</p></li>
-                <li class="pillar-card"><h3>Moral/Ethical Development</h3><p>The liminal phase imparts sacred lore, laws, and values, ensuring cultural continuity.</p></li>
-            </ul>
+            <div class="core-pillars-grid fade-in visible">
+                <div class="pillar-card">
+                    <h3>Identity Formation</h3>
+                    <p>Rites create a dramatic break from childhood identity and confer adult status, often described as symbolic death and rebirth.</p>
+                </div>
+                <div class="pillar-card">
+                    <h3>Resilience</h3>
+                    <p>Enduring pain or hardship in ritual context teaches initiates they can withstand suffering, building lasting fortitude.</p>
+                </div>
+                <div class="pillar-card">
+                    <h3>Belonging</h3>
+                    <p>Shared ordeals forge intense bonds and affirm membership in the adult community.</p>
+                </div>
+                <div class="pillar-card">
+                    <h3>Moral/Ethical Development</h3>
+                    <p>The liminal phase imparts sacred lore, laws, and values, ensuring cultural continuity.</p>
+                </div>
+            </div>
         </div>
 
         <div class="subsection-container fade-in visible">
@@ -85,20 +117,20 @@
 
         <div class="subsection-container fade-in visible">
             <h2 class="subsection-title">Key Themes &amp; Insights</h2>
-            <ul class="core-pillars-grid">
-                <li class="pillar-card"><h3>Pain as a Teacher</h3><p>Pain is a crucible for transformation, teaching courage and discipline.</p></li>
-                <li class="pillar-card"><h3>Symbolic Death and Rebirth</h3><p>Symbols of death and rebirth mark the passage from child to adult.</p></li>
-                <li class="pillar-card"><h3>The Power of Secret Knowledge</h3><p>Access to previously forbidden knowledge binds initiates and marks adult status.</p></li>
-            </ul>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Takeaways for Episode Production</h2>
-            <h4>Narrative hook opportunities</h4>
-            <p class="manifesto-text">Begin with visceral vignettes like the Maasai circumcision or the Sateré-Mawé bullet ant ritual.</p>
-            <h4>Big questions</h4>
-            <p class="manifesto-text">In a world without formal rites, how do we know when we've become adults? Can we create new rites today?</p>
-            <p class="manifesto-text">Possible bridge: transition to discussions of modern resilience psychology or role of elders.</p>
+            <div class="core-pillars-grid fade-in visible">
+                <div class="pillar-card">
+                    <h3>Pain as a Teacher</h3>
+                    <p>Pain is a crucible for transformation, teaching courage and discipline.</p>
+                </div>
+                <div class="pillar-card">
+                    <h3>Symbolic Death and Rebirth</h3>
+                    <p>Symbols of death and rebirth mark the passage from child to adult.</p>
+                </div>
+                <div class="pillar-card">
+                    <h3>The Power of Secret Knowledge</h3>
+                    <p>Access to previously forbidden knowledge binds initiates and marks adult status.</p>
+                </div>
+            </div>
         </div>
 
         <div class="subsection-container fade-in visible">

--- a/research/research_htmls/Ep3.html
+++ b/research/research_htmls/Ep3.html
@@ -40,21 +40,42 @@
 
         <div class="subsection-container fade-in visible">
             <h2 class="subsection-title">Historical &amp; Cultural Context</h2>
-            <ul class="manifesto-text">
-                <li><strong>Maasai Moran (East Africa):</strong> Circumcision and a period of warrior life transmit indigenous knowledge and identity.</li>
-                <li><strong>Spartan Agoge (Ancient Greece):</strong> Boys trained from age seven in endurance, discipline, and loyalty to the state.</li>
-                <li><strong>Native American Vision Quest:</strong> Solitary fasting and guidance from elders to receive a vision shaping adult roles.</li>
-            </ul>
+            <div class="episodes-grid fade-in visible">
+                <div class="episode-card">
+                    <h3>Maasai Moran (East Africa)</h3>
+                    <p class="hook">Circumcision and a period of warrior life transmit indigenous knowledge and identity.</p>
+                </div>
+                <div class="episode-card">
+                    <h3>Spartan Agoge (Ancient Greece)</h3>
+                    <p class="hook">Boys trained from age seven in endurance, discipline, and loyalty to the state.</p>
+                </div>
+                <div class="episode-card">
+                    <h3>Native American Vision Quest</h3>
+                    <p class="hook">Solitary fasting and guidance from elders to receive a vision shaping adult roles.</p>
+                </div>
+            </div>
         </div>
 
         <div class="subsection-container fade-in visible">
             <h2 class="subsection-title">Psychological Functions</h2>
-            <ul class="core-pillars-grid">
-                <li class="pillar-card"><h3>Identity Formation</h3><p>Rituals mark the transition with communal recognition, solidifying a new sense of self.</p></li>
-                <li class="pillar-card"><h3>Resilience</h3><p>Ordeals test and build strength, instilling competence for future adversity.</p></li>
-                <li class="pillar-card"><h3>Belonging</h3><p>Shared experiences create "communitas," confirming one's role within the group.</p></li>
-                <li class="pillar-card"><h3>Moral/Ethical Development</h3><p>Liminal instruction transmits sacred lore, laws, and values across generations.</p></li>
-            </ul>
+            <div class="core-pillars-grid fade-in visible">
+                <div class="pillar-card">
+                    <h3>Identity Formation</h3>
+                    <p>Rituals mark the transition with communal recognition, solidifying a new sense of self.</p>
+                </div>
+                <div class="pillar-card">
+                    <h3>Resilience</h3>
+                    <p>Ordeals test and build strength, instilling competence for future adversity.</p>
+                </div>
+                <div class="pillar-card">
+                    <h3>Belonging</h3>
+                    <p>Shared experiences create "communitas," confirming one's role within the group.</p>
+                </div>
+                <div class="pillar-card">
+                    <h3>Moral/Ethical Development</h3>
+                    <p>Liminal instruction transmits sacred lore, laws, and values across generations.</p>
+                </div>
+            </div>
         </div>
 
         <div class="subsection-container fade-in visible">
@@ -67,20 +88,20 @@
 
         <div class="subsection-container fade-in visible">
             <h2 class="subsection-title">Key Themes &amp; Insights</h2>
-            <ul class="core-pillars-grid">
-                <li class="pillar-card"><h3>Death and Rebirth</h3><p>Initiation enacts the symbolic death of the old self and birth of the new.</p></li>
-                <li class="pillar-card"><h3>The Liminal Space</h3><p>Transformation occurs in a vulnerable, potent "in-between" state.</p></li>
-                <li class="pillar-card"><h3>The Hero's Journey</h3><p>Joseph Campbell's monomyth mirrors initiation: separation, trials, and return.</p></li>
-            </ul>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Takeaways for Episode Production</h2>
-            <h4>Narrative hook opportunities</h4>
-            <p class="manifesto-text">Open with a vivid initiation story, such as a Maasai warrior facing a lion or a youth on a vision quest.</p>
-            <h4>Big questions</h4>
-            <p class="manifesto-text">What initiations do we experience today, and how do we mark them without formal rites?</p>
-            <p class="manifesto-text">Possible bridge: explore modern creations of new rites or impacts of failed initiations.</p>
+            <div class="core-pillars-grid fade-in visible">
+                <div class="pillar-card">
+                    <h3>Death and Rebirth</h3>
+                    <p>Initiation enacts the symbolic death of the old self and birth of the new.</p>
+                </div>
+                <div class="pillar-card">
+                    <h3>The Liminal Space</h3>
+                    <p>Transformation occurs in a vulnerable, potent "in-between" state.</p>
+                </div>
+                <div class="pillar-card">
+                    <h3>The Hero's Journey</h3>
+                    <p>Joseph Campbell's monomyth mirrors initiation: separation, trials, and return.</p>
+                </div>
+            </div>
         </div>
 
         <div class="subsection-container fade-in visible">

--- a/research/research_htmls/Ep4.html
+++ b/research/research_htmls/Ep4.html
@@ -38,22 +38,42 @@
 
         <div class="subsection-container fade-in visible">
             <h2 class="subsection-title">Historical &amp; Cultural Context</h2>
-            <h3>Key traditions</h3>
-            <ul class="manifesto-text">
-                <li><strong>Spartan Krypteia:</strong> Selected youth survive a year in the wilderness, enforcing Spartan law.</li>
-                <li><strong>Aboriginal Walkabout:</strong> A 13-year-old navigates the outback alone using ancestral songlines.</li>
-                <li><strong>Maasai Lion Hunt:</strong> Young men historically hunted lions to prove bravery and readiness to protect the community.</li>
-            </ul>
+            <div class="episodes-grid fade-in visible">
+                <div class="episode-card">
+                    <h3>Spartan Krypteia</h3>
+                    <p class="hook">Selected youth survive a year in the wilderness, enforcing Spartan law.</p>
+                </div>
+                <div class="episode-card">
+                    <h3>Aboriginal Walkabout</h3>
+                    <p class="hook">A 13-year-old navigates the outback alone using ancestral songlines.</p>
+                </div>
+                <div class="episode-card">
+                    <h3>Maasai Lion Hunt</h3>
+                    <p class="hook">Young men historically hunted lions to prove bravery and readiness to protect the community.</p>
+                </div>
+            </div>
         </div>
 
         <div class="subsection-container fade-in visible">
             <h2 class="subsection-title">Psychological Functions</h2>
-            <ul class="core-pillars-grid">
-                <li class="pillar-card"><h3>Identity Formation</h3><p>Rites answer "Who am I?" by testing and bestowing new adult roles, resolving Erikson's identity crisis.</p></li>
-                <li class="pillar-card"><h3>Resilience</h3><p>Ordeal builds "earned confidence" through voluntary confrontation with hardship.</p></li>
-                <li class="pillar-card"><h3>Belonging</h3><p>Communal trials activate loyalty and bind initiates to elders and tradition.</p></li>
-                <li class="pillar-card"><h3>Moral/Ethical Development</h3><p>Challenges create cognitive conflict, advancing moral reasoning to duty and social order.</p></li>
-            </ul>
+            <div class="core-pillars-grid fade-in visible">
+                <div class="pillar-card">
+                    <h3>Identity Formation</h3>
+                    <p>Rites answer "Who am I?" by testing and bestowing new adult roles, resolving Erikson's identity crisis.</p>
+                </div>
+                <div class="pillar-card">
+                    <h3>Resilience</h3>
+                    <p>Ordeal builds "earned confidence" through voluntary confrontation with hardship.</p>
+                </div>
+                <div class="pillar-card">
+                    <h3>Belonging</h3>
+                    <p>Communal trials activate loyalty and bind initiates to elders and tradition.</p>
+                </div>
+                <div class="pillar-card">
+                    <h3>Moral/Ethical Development</h3>
+                    <p>Challenges create cognitive conflict, advancing moral reasoning to duty and social order.</p>
+                </div>
+            </div>
         </div>
 
         <div class="subsection-container fade-in visible">
@@ -67,20 +87,20 @@
 
         <div class="subsection-container fade-in visible">
             <h2 class="subsection-title">Key Themes &amp; Insights</h2>
-            <ul class="core-pillars-grid">
-                <li class="pillar-card"><h3>Character is Forged, Not Given</h3><p>Virtue and confidence arise from overcoming adversity.</p></li>
-                <li class="pillar-card"><h3>The Necessity of the Threshold</h3><p>Adulthood requires crossing a challenging boundary.</p></li>
-                <li class="pillar-card"><h3>Biology Needs a Blueprint</h3><p>Rites harness adolescent risk-taking and identity seeking for growth.</p></li>
-            </ul>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Takeaways for Episode Production</h2>
-            <h4>Narrative hook opportunities</h4>
-            <p class="manifesto-text">Open with the story of a Spartan in the Krypteia or an Aboriginal youth on walkabout, contrasted with a modern teen facing a rock wall.</p>
-            <h4>Big questions</h4>
-            <p class="manifesto-text">Have we deprived youth of necessary challenges? How can we create meaningful rites today?</p>
-            <p class="manifesto-text">Possible bridge: exploring post-traumatic growth and unchosen ordeals.</p>
+            <div class="core-pillars-grid fade-in visible">
+                <div class="pillar-card">
+                    <h3>Character is Forged, Not Given</h3>
+                    <p>Virtue and confidence arise from overcoming adversity.</p>
+                </div>
+                <div class="pillar-card">
+                    <h3>The Necessity of the Threshold</h3>
+                    <p>Adulthood requires crossing a challenging boundary.</p>
+                </div>
+                <div class="pillar-card">
+                    <h3>Biology Needs a Blueprint</h3>
+                    <p>Rites harness adolescent risk-taking and identity seeking for growth.</p>
+                </div>
+            </div>
         </div>
 
         <div class="subsection-container fade-in visible">


### PR DESCRIPTION
## Summary
- Refactor Ep2-Ep4 research briefs to match Ep1 styling
- Remove episode production sections
- Use card-based grids for historical context, psychological functions, and key themes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ce7d572483239123089f4822d57c