### PR TITLE
Add episode takeaways to research HTML guides

### DIFF
--- a/research/research_htmls/Ep1.html
+++ b/research/research_htmls/Ep1.html
@@ -137,6 +137,15 @@
             </ul>
             <p class="manifesto-text">Selected web &amp; ethnographic sources: Britannica — Vision Quest; World History Encyclopedia — Agoge; Emuratta ceremony (Maasai); Liminality (Wikipedia).</p>
         </div>
+
+        <div class="subsection-container fade-in visible">
+            <h2 class="subsection-title">Takeaways for Episode / Podcast Integration</h2>
+            <ul class="manifesto-text">
+                <li><strong>Narrative hook opportunities:</strong> Begin with a vivid story of a specific rite, like the Sateré-Mawé boys putting their hands into gloves filled with bullet ants, or a young Maasai facing circumcision without anesthesia. Contrast this immediately with the ambiguity of a modern 22-year-old living at home, unsure if they are truly an adult.</li>
+                <li><strong>Big question(s) to leave the listener with:</strong> "In a society that has lost its roadmap to adulthood, how are we supposed to find our way?" or "If you had to design a rite of passage for young people today, what would it include?"</li>
+                <li><strong>Possible bridges to next episode:</strong> "We've seen how traditional cultures handled this transition. Next time, we'll talk to psychologists and program leaders who are trying to build new rites of passage for the 21st century."</li>
+            </ul>
+        </div>
     </section>
 </body>
 </html>

--- a/research/research_htmls/Ep2.html
+++ b/research/research_htmls/Ep2.html
@@ -150,6 +150,15 @@
                 <li>Xenophon. <em>The Polity of the Lacedaemonians</em>.</li>
             </ul>
         </div>
+
+        <div class="subsection-container fade-in visible">
+            <h2 class="subsection-title">Takeaways for Episode / Podcast Integration</h2>
+            <ul class="manifesto-text">
+                <li><strong>Narrative Hook Opportunities:</strong> Start with a vivid, visceral vignette: the flash of the circumciser's knife for the Maasai boy, the deafening roar of the "forest spirit" for the Okiek initiate, or the first agonizing sting of the bullet ant for the Sateré-Mawé youth. The story of the Spartan boy and the fox is also a powerful hook.</li>
+                <li><strong>Big Question(s) to Leave the Listener With:</strong> In a world without formal rites of passage, how do we know when we've truly become adults? What have we lost by replacing profound, community-led ordeals with the isolated, often un-witnessed challenges of modern life? Can we, and should we, create new rites of passage for our time?</li>
+                <li><strong>Possible Bridges to Next Episode:</strong> If the next episode is about modern challenges to masculinity or femininity, this episode provides a powerful historical baseline. It could also transition to a discussion of the role of elders in society, or the psychology of resilience and post-traumatic growth.</li>
+            </ul>
+        </div>
     </section>
 </body>
 </html>

--- a/research/research_htmls/Ep3.html
+++ b/research/research_htmls/Ep3.html
@@ -135,6 +135,15 @@
                 <li>(TikTok, 2024)</li>
             </ul>
         </div>
+
+        <div class="subsection-container fade-in visible">
+            <h2 class="subsection-title">Takeaways for Episode / Podcast Integration</h2>
+            <ul class="manifesto-text">
+                <li><strong>Narrative hook opportunities:</strong> Start with a vivid story of a specific initiation rite, like a young Maasai warrior facing a lion or a Native American youth on a vision quest, to immediately engage the listener.</li>
+                <li><strong>Big question(s) to leave the listener with:</strong> What are the "initiations" we go through in our own lives, and how do we mark them? In a world without formal rites of passage, how do we know when we've truly become adults?</li>
+                <li><strong>Possible bridges to next episode:</strong> The next episode could explore how individuals and groups are creating new, modern rites of passage to fill this cultural void, or delve deeper into the psychological impact of "failed" or absent initiations.</li>
+            </ul>
+        </div>
     </section>
 </body>
 </html>

--- a/research/research_htmls/Ep4.html
+++ b/research/research_htmls/Ep4.html
@@ -115,6 +115,15 @@
                 <li>Outward Bound</li>
             </ul>
         </div>
+
+        <div class="subsection-container fade-in visible">
+            <h2 class="subsection-title">Takeaways for Episode / Podcast Integration</h2>
+            <ul class="manifesto-text">
+                <li><strong>Narrative hook opportunities:</strong> Begin with the visceral story of a young Spartan enduring the Krypteia or an Aboriginal youth finding his way through the outback. Contrast this with the story of Aisha, the modern teen terrified of a rock-climbing wall in Outward Bound, to show the timeless nature of the challenge.</li>
+                <li><strong>Big question(s) to leave the listener with:</strong> In a modern world that prioritizes safety and comfort, have we deprived our youth of the necessary challenges to truly grow up? How can we create meaningful, positive "rites of passage" in our families, schools, and communities today?</li>
+                <li><strong>Possible bridges to next episode:</strong> "We've seen how crucial structured ordeals are for moral development. But what happens when ordeals are not chosen, when crisis and trauma strike unexpectedly? Next time, we explore the psychology of post-traumatic growth—how profound adversity can sometimes lead to profound wisdom."</li>
+            </ul>
+        </div>
     </section>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add "Takeaways for Episode / Podcast Integration" sections to Ep1-4 research HTML guides, highlighting narrative hooks, key questions, and bridges to future episodes.

## Testing
- ⚠️ `npm test` *(command not found)*
- ⚠️ `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cfd4cc308323a40b7b2e7636c0ff