### PR TITLE
Regenerate episode research HTMLs

### DIFF
--- a/research/convert_md_to_html.py
+++ b/research/convert_md_to_html.py
@@ -1,0 +1,85 @@
+import re
+from pathlib import Path
+
+def inline(text: str) -> str:
+    """Apply basic Markdown inline formatting."""
+    text = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<a href="\2">\1</a>', text)
+    text = re.sub(r'\*\*([^*]+)\*\*', r'<strong>\1</strong>', text)
+    text = re.sub(r'\*([^*]+)\*', r'<em>\1</em>', text)
+    return text
+
+def convert(md: str) -> str:
+    lines = md.splitlines()
+    html = []
+    stack = []  # (list_type, indent)
+    def close_to(indent: int) -> None:
+        while stack and indent < stack[-1][1]:
+            html.append(f'</{stack.pop()[0]}>')
+    def close_all() -> None:
+        while stack:
+            html.append(f'</{stack.pop()[0]}>')
+    for line in lines:
+        if not line.strip():
+            continue
+        stripped = line.strip()
+        if re.match(r'^---+$', stripped):
+            close_all()
+            html.append('<hr/>')
+            continue
+        m = re.match(r'^(#{1,6})\s+(.*)', stripped)
+        if m:
+            close_all()
+            level = len(m.group(1))
+            html.append(f'<h{level}>{inline(m.group(2))}</h{level}>')
+            continue
+        m = re.match(r'^(\s*)([*\-]|\d+\.)\s+(.*)', line)
+        if m:
+            indent = len(m.group(1))
+            marker = m.group(2)
+            content = inline(m.group(3))
+            list_type = 'ul' if marker in ('*', '-') else 'ol'
+            close_to(indent)
+            if not stack or indent > stack[-1][1]:
+                stack.append((list_type, indent))
+                html.append(f'<{list_type}>')
+            elif stack[-1][0] != list_type:
+                html.append(f'</{stack.pop()[0]}>')
+                stack.append((list_type, indent))
+                html.append(f'<{list_type}>')
+            html.append(f'<li>{content}</li>')
+            continue
+        close_all()
+        html.append(f'<p>{inline(stripped)}</p>')
+    close_all()
+    return '\n'.join(html)
+
+def process_episode(ep: int) -> None:
+    md_path = Path('research/All Research PDFs') / f'Ep{ep}_Research_Brief.md'
+    text = md_path.read_text(encoding='utf-8')
+    # Remove "Takeaways" section and anything after it
+    text = re.sub(r'\n##\s*\d+\.\s*Takeaways for Episode / Podcast Integration[\s\S]*', '', text)
+    html_body = convert(text)
+    template = f"""<!DOCTYPE html>
+<html lang='en'>
+<head>
+    <meta charset='UTF-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+    <title>Ep{ep} Research Brief</title>
+    <link rel='preconnect' href='https://fonts.googleapis.com'>
+    <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
+    <link href='https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Inter:wght@300;400;500;600&display=swap' rel='stylesheet'>
+    <link rel='stylesheet' href='ResearchGuideStyles.css'>
+</head>
+<body>
+<section class='section-container'>
+{html_body}
+</section>
+</body>
+</html>
+"""
+    out_path = Path('research/research_htmls') / f'Ep{ep}.html'
+    out_path.write_text(template, encoding='utf-8')
+
+if __name__ == '__main__':
+    for ep in range(1, 5):
+        process_episode(ep)

--- a/research/research_htmls/Ep1.html
+++ b/research/research_htmls/Ep1.html
@@ -1,142 +1,102 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang='en'>
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Rites of Passage: The Call to the Unknown</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="ResearchGuideStyles.css">
+    <meta charset='UTF-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+    <title>Ep1 Research Brief</title>
+    <link rel='preconnect' href='https://fonts.googleapis.com'>
+    <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
+    <link href='https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Inter:wght@300;400;500;600&display=swap' rel='stylesheet'>
+    <link rel='stylesheet' href='ResearchGuideStyles.css'>
 </head>
 <body>
-    <section class="section-container">
-        <!-- Hero Summary Box -->
-        <div class="hero-summary-box">
-            <div class="research-brief-label">Research Brief</div>
-
-            <div class="episode-title-block">
-                <span class="episode-prefix">Episode 1:</span>
-                <h1 class="main-title">The Call to the Unknown</h1>
-            </div>
-            <p class="hero-tagline">Embracing the First Step</p>
-
-            <div class="executive-summary">
-                <h2>Executive Summary</h2>
-                <p>This brief examines the first stage of traditional rites of passage—separation—and why it matters for identity, resilience, belonging, and moral formation. Drawing on cross-cultural ethnography and psychological theory, the document argues that deliberate separation (symbolic or physical) creates a necessary rupture from childhood that allows a coherent adult identity to be formed. In contemporary societies the weakening or absence of clearly structured separations contributes to extended adolescence, anxiety, and the search for ad-hoc, often risky, substitutes.</p>
-            </div>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Core Concept / Framework</h2>
-            <h3>Anchor theory: Arnold van Gennep’s three-stage model (Separation → Liminality → Reintegration)</h3>
-            <p class="manifesto-text">Initiation rituals reliably follow three phases. Separation removes the initiate from prior roles; liminality places them in an ambiguous, often pedagogical and testing, condition; reintegration ceremonially returns them with new status.</p>
-
-            <div class="van-gennep-diagram fade-in visible">
-                <span class="stage">Separation</span>
-                <span class="arrow">&rarr;</span>
-                <span class="stage">Liminality</span>
-                <span class="arrow">&rarr;</span>
-                <span class="stage">Reintegration</span>
-            </div>
-
-            <div class="pull-quote fade-in visible" style="margin-top:1rem;">
-                <p>The chrysalis metaphor: separation creates the container in which the old self dissolves so a new form can emerge.</p>
-            </div>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Historical & Cultural Context (select examples)</h2>
-            <div class="episodes-grid fade-in visible">
-                <div class="episode-card">
-                    <h3>Maasai (East Africa)</h3>
-                    <p class="hook">Enkipaata and Emuratta phases—training, public circumcision, and Eunoto hair-shaving ceremonies mark rebirth into warrior age-sets.</p>
-                </div>
-                <div class="episode-card">
-                    <h3>Sparta (Ancient Greece)</h3>
-                    <p class="hook">The <em>Agoge</em> separated boys from family life at age seven and imposed prolonged communal training that functioned as a civil death and rebirth.</p>
-                </div>
-                <div class="episode-card">
-                    <h3>Native American Plains (e.g., Lakota)</h3>
-                    <p class="hook">Vision quests involve solitary fasting and exposure; elders later interpret visions and incorporate the youth's new spiritual status into community roles.</p>
-                </div>
-            </div>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Psychological Functions</h2>
-            <div class="core-pillars-grid balanced-2-col fade-in visible">
-                <div class="pillar-card">
-                    <h3>Identity formation</h3>
-                    <p>Ritualized separation produces a clear before/after marker. Symbols (new names, shaved hair, scarification) enact a social death of the child self and provide a memorable anchor for a new adult identity.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>Resilience</h3>
-                    <p>Ordeals expose initiates to controlled hardship. Surviving these trials cultivates "earned confidence" and competencies required for adult roles.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>Belonging</h3>
-                    <p>Separation sets the stage for reintegration where the community publicly acknowledges the initiate’s new status; this validation secures social belonging and obligations.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>Moral &amp; ethical formation</h3>
-                    <p>Liminal periods allow elders to transmit core values and narratives, and to guide initiates through shadow integration and ethical teaching.</p>
-                </div>
-            </div>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Modern Echoes: Successes and Limitations</h2>
-            <div class="episodes-grid fade-in visible">
-                <div class="episode-card">
-                    <h3>Military boot camps</h3>
-                    <p class="hook">Explicit separation, intense liminality, followed by ceremonial reintegration—effective for cohesion and identity change.</p>
-                </div>
-                <div class="episode-card">
-                    <h3>Religious rites (confirmation, bar/bat mitzvah)</h3>
-                    <p class="hook">Symbolic thresholds that vary in depth and later social consequences.</p>
-                </div>
-                <div class="episode-card">
-                    <h3>Wilderness programs, gap years, and adventure retreats</h3>
-                    <p class="hook">Can approximate separation and liminality but often lack structured reintegration and elder-led meaning-making.</p>
-                </div>
-                <div class="episode-card">
-                    <h3>Pseudo-rites (gang initiation, hazing)</h3>
-                    <p class="hook">Provide belonging and identity change but frequently in harmful forms and without prosocial moral instruction.</p>
-                </div>
-            </div>
-            <p class="manifesto-text" style="text-align:center; margin-top: 1.5rem;">Modern programs succeed when they preserve all three stages and include elder recognition; they fail when they omit reintegration or community endorsement.</p>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Key Themes &amp; Insights</h2>
-            <div class="core-pillars-grid fade-in visible">
-                <div class="pillar-card">
-                    <h3>The essential rupture</h3>
-                    <p>Deliberate disconnection from prior status is a necessary precondition for genuine identity change.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>Resilience requires structure</h3>
-                    <p>Ordeal without ritual frame can be traumatic; within a rite it becomes transformative.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>Adulthood is validated socially</h3>
-                    <p>Personal change attains cultural purchase only when publicly witnessed and confirmed.</p>
-                </div>
-            </div>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Citations &amp; Suggested Sources</h2>
-            <ul class="manifesto-text research-links">
-                <li>Van Gennep, A. (1909). <em>The Rites of Passage</em>.</li>
-                <li>Turner, V. (1969). <em>The Ritual Process: Structure and Anti-Structure</em>.</li>
-                <li>Erikson, E. H. (1968). <em>Identity, Youth and Crisis</em>.</li>
-                <li>Jung, C. G. (selected writings on individuation and the shadow).</li>
-                <li>Bandura, A. (1977). <em>Self-efficacy</em>.</li>
-            </ul>
-            <p class="manifesto-text">Selected web &amp; ethnographic sources: Britannica — Vision Quest; World History Encyclopedia — Agoge; Emuratta ceremony (Maasai); Liminality (Wikipedia).</p>
-        </div>
-    </section>
+<section class='section-container'>
+<h1>Research Brief – Rites of Passage: The Lost Map to Adulthood</h1>
+<h2>1. Executive Summary</h2>
+<p>This episode explores traditional rites of passage—the structured ceremonies that have guided youth into adulthood across cultures for millennia. These rituals typically follow a universal three-stage pattern of separation, a transitional "liminal" phase of testing, and communal reintegration. The core psychological insight is that these rites serve essential functions: forging a stable adult identity, building resilience through ordeal, cementing a sense of belonging, and transmitting moral values. This topic matters because the general absence of such formal rites in modern society contributes to a prolonged, ambiguous adolescence, leaving many young people to seek out their own risky, "DIY" initiations to answer the question, "Am I an adult now?".</p>
+<hr/>
+<h2>2. Core Concept / Framework</h2>
+<ul>
+<li><strong>Anchor theory or model:</strong> The primary framework is Anthropologist Arnold van Gennep's three-stage model of rites of passage, outlined in his 1909 work, <em>The Rites of Passage</em>.</li>
+<li><strong>Definition in plain language:</strong> Van Gennep observed that initiation rituals worldwide follow a consistent pattern:</li>
+<ol>
+<li><strong>Separation:</strong> The initiate is physically or symbolically removed from their old life and childhood identity.</li>
+<li><strong>Liminality:</strong> The initiate enters an ambiguous "in-between" state, a threshold where they are no longer a child but not yet an adult. This phase often involves ordeals, tests, and secret teachings.</li>
+<li><strong>Reintegration (or Incorporation):</strong> The initiate is ceremonially welcomed back into the community with a new, recognized adult status.</li>
+</ol>
+<li><strong>Short illustrative example or metaphor:</strong> The liminal stage is often compared to a chrysalis. The caterpillar (the child) dissolves into a state of pure potential before emerging as a butterfly (the adult).</li>
+</ul>
+<hr/>
+<h2>3. Historical & Cultural Context</h2>
+<ul>
+<li><strong>Key traditions or societies that embody the concept:</strong></li>
+<ul>
+<li><strong>Maasai (East Africa):</strong> Young men undergo a pre-initiation training phase (Enkipaata), a public circumcision ordeal (Emuratta) which they must endure without flinching, and a ceremony (Eunoto) where their long hair is shaved to symbolize rebirth as a senior warrior.</li>
+<li><strong>Spartans (Ancient Greece):</strong> Boys were taken from their homes at age seven to enter the <em>Agoge</em>, a brutal, years-long military training program designed to strip their civilian identity and forge them into soldiers. Graduation and acceptance into a communal dining mess marked their reintegration as citizens.</li>
+<li><strong>Native Americans (Plains Cultures):</strong> The Vision Quest involves an adolescent fasting in solitude for several days to receive a spiritual vision that will guide their adult life. Elders help interpret the vision, integrating the youth's new spiritual identity into the community.</li>
+<li><strong>Australian Aboriginals:</strong> Some groups practiced initiation rites like the Wilyaru, where boys were covered in the blood of elders and had teeth knocked out to symbolize the death of childhood and rebirth as men connected to the ancestral life-force.</li>
+</ul>
+</ul>
+<hr/>
+<h2>4. Psychological Functions</h2>
+<ul>
+<li><strong>Identity formation (how the rite guides selfhood):</strong> Rites create a clear "before-and-after" moment that resolves adolescent identity confusion. They often involve potent symbols of "death and rebirth," such as shaving the head or receiving a new name, to kill off the child self and solidify a new adult identity. This process answers the adolescent question, "Who am I becoming?" with a clear, unforgettable answer.</li>
+<li><strong>Resilience (ordeal, hardship, testing):</strong> Nearly all rites of passage involve an ordeal—a physically or psychologically demanding trial. Overcoming these challenges, like the Maasai circumcision or the Sateré-Mawé bullet ant glove ritual, builds genuine resilience, courage, and a visceral sense of competence that proves the initiate is ready for adult challenges.</li>
+<li><strong>Belonging (integration into community):</strong> The final reintegration phase is a critical public affirmation where the community formally acknowledges and celebrates the initiate's new status. This is often done through feasts, dances, and inclusion in new social groups (like Maasai age-sets), which addresses the deep human need to belong and feel valued by one's group.</li>
+<li><strong>Moral/ethical development (values, shadow work, discipline):</strong> The liminal period is a classroom for life skills and ethics. Elders mentor initiates, transmitting the culture's core values, sacred stories, and moral codes. According to Jungian psychology, this is also a time to confront and integrate the "shadow"—the hidden, darker aspects of the personality—to develop a more whole and authentic self.</li>
+</ul>
+<hr/>
+<h2>5. Modern Echoes</h2>
+<ul>
+<li><strong>Parallels in today’s world:</strong> Military boot camps are a prime example, using separation (shaved heads), a liminal phase (rigorous training), and reintegration (graduation ceremony) to forge a new identity. Other echoes include religious ceremonies like confirmations or bar mitzvahs, college fraternity hazing, and endurance challenges like "Spartan Races."</li>
+<li><strong>Where these echoes succeed or fail:</strong> Military training is highly effective at creating unit cohesion and personal development. However, many modern echoes fail because they lack one or more key elements. Gang initiations and fraternity hazing are often dangerous "pseudo-rites" without elder wisdom. Even positive programs like wilderness adventures can be less impactful if they omit the crucial community reintegration phase upon the initiate's return.</li>
+<li><strong>Implications for adolescence/adulthood now:</strong> The lack of formal rites has led to "extended adolescence," where the transition to adulthood is prolonged and ambiguous. This can lead to anxiety, aimlessness, and the rise of risky behaviors as young people unconsciously seek to prove themselves.</li>
+</ul>
+<hr/>
+<h2>6. Key Themes & Insights</h2>
+<ul>
+<li><strong>Theme 1: The Power of a Clear Threshold.</strong> Traditional rites provide an unambiguous line between childhood and adulthood, resolving the identity confusion that characterizes modern adolescence.</li>
+<li><strong>Theme 2: Resilience is Forged, Not Given.</strong> The ordeal is central to initiation because overcoming real, meaningful challenges is what builds earned confidence and the psychological toughness required for adulthood.</li>
+<li><strong>Theme 3: Adulthood is a Community Act.</strong> An individual's transformation is not complete until it is witnessed, acknowledged, and celebrated by their community; belonging is the final piece of the puzzle.</li>
+</ul>
+<hr/>
+<h2>7. Citations & Sources</h2>
+<ul>
+<li><strong>(Van Gennep, 1909)</strong> As cited in "Rites of Passage: Universal Functions Across Cultures" and "Adolescence as a Liminal State."</li>
+<li><strong>(Erikson, Erik)</strong> As cited in "Adolescence as a Liminal State: Identity, Challenges, and Rites of Passage."</li>
+<li><strong>(Turner, Victor)</strong> As cited in "Rites of Passage: Universal Functions Across Cultures" and "Adolescence as a Liminal State."</li>
+<li><strong>(Jung, Carl)</strong> As cited in "Adolescence as a Liminal State: Identity, Challenges, and Rites of Passage."</li>
+<li><strong>(Aronson & Mills, 1959)</strong> As cited in "Rites of Passage: Universal Functions Across Cultures."</li>
+</ul>
+<p><strong>Web Sources:</strong></p>
+<ol>
+<li><strong>Arnold van Gennep and the Rites of Passage: Illuminating the Structure of Human Transitions:</strong> https://gettherapybirmingham.com/arnold-van-gennep-and-the-rites-of-passage-illuminating-the-structure-of-human-transitions/</li>
+<li><strong>Rite of passage - Wikipedia:</strong> https://en.wikipedia.org/wiki/Rite_of_passage</li>
+<li><strong>[EPUB] Rites and Symbols of Initiation: The Mysteries of Birth and Rebirth:</strong> https://dokumen.pub/download/rites-and-symbols-of-initiation-the-mysteries-of-birth-and-rebirth-978-0-88214-598-3-9780882143583-0882143581.html</li>
+<li><strong>Maasai Rituals and Ceremonies:</strong> https://100humanitarians.org/maasai-rites</li>
+<li><strong>Religion Chapter 2 Flashcards | Quizlet:</strong> https://quizlet.com/318730642/religion-chapter-2-flash-cards/</li>
+<li><strong>Vision quest | Native American Rituals & Beliefs | Britannica:</strong> https://www.britannica.com/topic/vision-quest</li>
+<li><strong>Seven Lakota Rites - St. Joseph's Indian School:</strong> https://www.stjo.org/native-american-culture/seven-lakota-rites/</li>
+<li><strong>Vision Quest | The Canadian Encyclopedia:</strong> https://thecanadianencyclopedia.ca/en/article/vision-quest</li>
+<li><strong>Agoge - Wikipedia:</strong> https://en.wikipedia.org/wiki/Agoge</li>
+<li><strong>Agoge, the Spartan Education Program - World History Encyclopedia:</strong> https://www.worldhistory.org/article/342/agoge-the-spartan-education-program/</li>
+<li><strong>Emuratta Ceremony - Masai Mara National Reserve:</strong> https://masaimarapark.com/emuratta-ceremony/</li>
+<li><strong>Rites of Passage: How Our Ancestors Handled the Teen Years | Rustic Pathways:</strong> https://rusticpathways.com/inside-rustic/online-magazine/rites-of-passage-how-our-ancestors-handled-the-teen-years</li>
+<li><strong>Aboriginal Culture and Ceremonies:</strong> https://mbantua.com.au/aboriginal-culture/?srsltid=AfmBOop1P7_pHooYNhk_dfImrNVTRWNAxyIDcUM7LwLViR2IX8UxlQGr</li>
+<li><strong>Liminality - Wikipedia:</strong> https://en.wikipedia.org/wiki/Liminality</li>
+<li><strong>The Power and Possibility of Liminal Moments:</strong> http://www.sandiaprep.org/why-prep/our-school/head-of-school-blog?id=421137/the-power-and-possibility-of-liminal-moments</li>
+<li><strong>Homeschooling Teens and Rites of Passage - Homeschool Connections:</strong> https://homeschoolconnections.com/homeschooling-teens-rites-passage/</li>
+<li><strong>Erikson's Stages of Development:</strong> https://www.simplypsychology.org/erik-erikson.html</li>
+<li><strong>Ritualized into adulthood: the scarcity of youth-focused rites of passage in America | Discover Global Society:</strong> https://link.springer.com/article/10.1007/s44282-023-00027-3</li>
+<li><strong>Shadow and Self in Adolescence: navigating rage, love, and individuation:</strong> https://thisjungianlife.com/adolescence/</li>
+<li><strong>Shadow (psychology) - Wikipedia:</strong> https://en.wikipedia.org/wiki/Shadow_(psychology)</li>
+<li><strong>The Jungian Shadow - The Society of Analytical Psychology:</strong> https://www.thesap.org.uk/articles-on-jungian-psychology-2/about-analysis-and-therapy/the-shadow/</li>
+<li><strong>Explaining variance in self-efficacy among adolescents... | BMC Public Health:</strong> https://bmcpublichealth.biomedcentral.com/articles/10.1186/s12889-023-16603-w</li>
+<li><strong>assets.cambridge.org:</strong> https://assets.cambridge.org/97810094/68503/excerpt/9781009468503_excerpt.pdf</li>
+<li><strong>What rights of passage for youth exist in modern America? - The Academic:</strong> https://theacademic.com/guiding-youths-into-adulthood/</li>
+<li><strong>The Hidden Cost of Missing Rites of Passage in Our Teens' Lives:</strong> https://radzatconsulting.com/blog/f/the-hidden-cost-of-missing-rites-of-passage-in-our-teens-lives?blogcategory=Parenting+Teens</li>
+</ol>
+<hr/>
+</section>
 </body>
 </html>

--- a/research/research_htmls/Ep2.html
+++ b/research/research_htmls/Ep2.html
@@ -1,155 +1,85 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang='en'>
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Rites of Passage: The Ordeal of Transformation</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="ResearchGuideStyles.css">
+    <meta charset='UTF-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+    <title>Ep2 Research Brief</title>
+    <link rel='preconnect' href='https://fonts.googleapis.com'>
+    <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
+    <link href='https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Inter:wght@300;400;500;600&display=swap' rel='stylesheet'>
+    <link rel='stylesheet' href='ResearchGuideStyles.css'>
 </head>
 <body>
-    <section class="section-container">
-        <!-- Hero Summary Box -->
-        <div class="hero-summary-box">
-            <div class="research-brief-label">Research Brief</div>
-
-            <div class="episode-title-block">
-                <span class="episode-prefix">Episode 2:</span>
-                <h1 class="main-title">The Liminal Crucible</h1>
-            </div>
-            <p class="hero-tagline">Enduring the Trials</p>
-
-            <div class="executive-summary">
-                <h2>Executive Summary</h2>
-                <p>This brief explores the structure, function, and symbolism of initiation rites across a range of indigenous and ancient European warrior cultures, including the Maasai of East Africa, the Okiek of Kenya, the Sateré-Mawé of the Amazon, Aboriginal Australians, Spartan warriors, the Norse, and the Celts. These rituals, while culturally distinct, universally serve to guide the transition from childhood to adulthood through a structured process of separation, ordeal, and reintegration. The central insight is that these rites psychologically fortify individuals for the hardships of adult life by creating a foundational memory of endurance and transformation. Understanding these practices offers profound insights into identity formation, community cohesion, and the universal human need for structured, meaningful transitions between life stages.</p>
-            </div>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Core Concept / Framework</h2>
-            <p>The primary framework for understanding these rites comes from the work of anthropologists Arnold van Gennep and Victor Turner.</p>
-            <ul class="manifesto-text">
-                <li><strong>Anchor Theory:</strong> Van Gennep's tripartite structure of "rites of passage" and Turner's elaboration on the concept of "liminality."</li>
-                <li><strong>Definition in Plain Language:</strong>
-                    <ol>
-                        <li><strong>Separation:</strong> The individual is removed from their familiar social setting and previous identity.</li>
-                        <li><strong>Liminality (Transition):</strong> The "in-between" stage where initiates are outside normal structures, often subjected to ordeals and sacred instruction.</li>
-                        <li><strong>Incorporation (Reintegration):</strong> Formal welcoming back into the community with a new status.</li>
-                    </ol>
-                </li>
-                <li><strong>Illustrative Metaphor:</strong> Like a caterpillar entering a chrysalis to emerge as a butterfly; the liminal phase transforms the individual before return.</li>
-            </ul>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Historical &amp; Cultural Context</h2>
-            <div class="episodes-grid fade-in visible">
-                <div class="episode-card">
-                    <h3>Maasai (East Africa)</h3>
-                    <p class="hook">The <em>Emurata</em> circumcision ceremony marks the transition to warriorhood.</p>
-                </div>
-                <div class="episode-card">
-                    <h3>Okiek (Kenya)</h3>
-                    <p class="hook">The <em>Tumdo</em> initiation involves seclusion and instruction in the forest.</p>
-                </div>
-                <div class="episode-card">
-                    <h3>Sateré-Mawé (Amazon)</h3>
-                    <p class="hook">The Tucandeira ritual uses bullet ant gloves repeated over years.</p>
-                </div>
-                <div class="episode-card">
-                    <h3>Aboriginal Australians</h3>
-                    <p class="hook">Rites such as the <em>Bora</em> and walkabouts connect youths to Dreaming and ancestral law.</p>
-                </div>
-                <div class="episode-card">
-                    <h3>Spartans (Ancient Greece)</h3>
-                    <p class="hook">The <em>Agōgē</em> was a state-run program beginning at age seven.</p>
-                </div>
-                <div class="episode-card">
-                    <h3>Norse (Viking Age)</h3>
-                    <p class="hook">Wilderness survival and symbolic transformation into animal-like warriors.</p>
-                </div>
-                <div class="episode-card">
-                    <h3>Celts (Iron Age Europe)</h3>
-                    <p class="hook">Legendary trials like those of the Fianna tested endurance and intellect.</p>
-                </div>
-            </div>
-            <h3>Narrative Anecdotes</h3>
-            <ul class="manifesto-text">
-                <li>A Maasai boy endures circumcision without flinching as his mother celebrates his symbolic rebirth.</li>
-                <li>Okiek initiates learn that a mythical beast's roar is created by a bullroarer, turning fear into secret knowledge.</li>
-                <li>A Sateré-Mawé youth dances while wearing bullet ant gloves, repeating the ordeal up to 20 times.</li>
-                <li>A Spartan boy hides a stolen fox, allowing it to gnaw him to death rather than cry out.</li>
-            </ul>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Psychological Functions</h2>
-            <div class="core-pillars-grid fade-in visible">
-                <div class="pillar-card">
-                    <h3>Identity Formation</h3>
-                    <p>Rites create a dramatic break from childhood identity and confer adult status, often described as symbolic death and rebirth.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>Resilience</h3>
-                    <p>Enduring pain or hardship in ritual context teaches initiates they can withstand suffering, building lasting fortitude.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>Belonging</h3>
-                    <p>Shared ordeals forge intense bonds and affirm membership in the adult community.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>Moral/Ethical Development</h3>
-                    <p>The liminal phase imparts sacred lore, laws, and values, ensuring cultural continuity.</p>
-                </div>
-            </div>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Modern Echoes</h2>
-            <ul class="manifesto-text">
-                <li><strong>Parallels Today:</strong> Military boot camps, fraternity/sorority hazing, medical residencies, extreme sports, and wilderness therapy.</li>
-                <li><strong>Successes and Failures:</strong> Modern echoes build resilience and camaraderie but often lack sacred or cosmological meaning, risking descent into hazing or hollow endurance tests.</li>
-                <li><strong>Implications:</strong> Decline of formal rites links to prolonged adolescence and lack of identity; structured transitions are needed today.</li>
-            </ul>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Key Themes &amp; Insights</h2>
-            <div class="core-pillars-grid fade-in visible">
-                <div class="pillar-card">
-                    <h3>Pain as a Teacher</h3>
-                    <p>Pain is a crucible for transformation, teaching courage and discipline.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>Symbolic Death and Rebirth</h3>
-                    <p>Symbols of death and rebirth mark the passage from child to adult.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>The Power of Secret Knowledge</h3>
-                    <p>Access to previously forbidden knowledge binds initiates and marks adult status.</p>
-                </div>
-            </div>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Citations &amp; Suggested Sources</h2>
-            <ul class="manifesto-text research-links">
-                <li>(Eliade, 1958) Mircea Eliade, <em>Rites and Symbols of Initiation: The Mysteries of Birth and Rebirth</em>.</li>
-                <li>(Turner, 1969) Victor Turner, <em>The Ritual Process: Structure and Anti-Structure</em>.</li>
-                <li>(van Gennep, 1909) Arnold van Gennep, <em>Les Rites de Passage</em>.</li>
-                <li>Berndt, Ronald M., and Catherine H. Berndt. (1996). <em>The World of the First Australians</em>.</li>
-                <li>Cartledge, Paul. (2004). <em>The Spartans: The World of the Warrior-Heroes of Ancient Greece</em>.</li>
-                <li>Kratz, Corinne A. (1994). <em>Affecting Performance: Meaning and Movement in Okiek Women's Initiation</em>.</li>
-                <li>Mbiti, John S. (1970). <em>African Religions and Philosophy</em>.</li>
-                <li>Ole Saitoti, Tepilit. (1986). <em>The Worlds of a Maasai Warrior</em>.</li>
-                <li>Pontes, Marcos. (2018). "Tucandeira: Uma Tradição dos Sateré-Mawé."</li>
-                <li>Rolleston, T.W. (1911). <em>The Legends of the Celtic Race</em>.</li>
-                <li>Sturluson, Snorri. <em>Prose Edda</em>.</li>
-                <li>Xenophon. <em>The Polity of the Lacedaemonians</em>.</li>
-            </ul>
-        </div>
-    </section>
+<section class='section-container'>
+<h1>Research Brief – The Ordeal of Transformation: A Cross-Cultural Look at Initiation Rites</h1>
+<h2>1. Executive Summary</h2>
+<p>This brief explores the structure, function, and symbolism of initiation rites across a range of indigenous and ancient European warrior cultures, including the Maasai of East Africa, the Okiek of Kenya, the Sateré-Mawé of the Amazon, Aboriginal Australians, Spartan warriors, the Norse, and the Celts. These rituals, while culturally distinct, universally serve to guide the transition from childhood to adulthood through a structured process of separation, ordeal, and reintegration. The central insight is that these rites psychologically fortify individuals for the hardships of adult life by creating a foundational memory of endurance and transformation. Understanding these practices offers profound insights into identity formation, community cohesion, and the universal human need for structured, meaningful transitions between life stages.</p>
+<h2>2. Core Concept / Framework</h2>
+<p>The primary framework for understanding these rites comes from the work of anthropologists Arnold van Gennep and Victor Turner.</p>
+<ul>
+<li><strong>Anchor Theory:</strong> Van Gennep's tripartite structure of "rites of passage" and Turner's elaboration on the concept of "liminality."</li>
+<li><strong>Definition in Plain Language:</strong> Van Gennep identified three distinct phases in any rite of passage:</li>
+<ol>
+<li><strong>Separation:</strong> The individual is removed from their familiar social setting and previous identity.</li>
+<li><strong>Liminality (Transition):</strong> This is the "in-between" stage, where the initiate is outside of society's normal structure, often subjected to ordeals and taught sacred knowledge. Turner described this phase as a state of ambiguity and potential, where the usual social hierarchies are dissolved.</li>
+<li><strong>Incorporation (Reintegration):</strong> The individual is formally welcomed back into the community with a new, recognized status.</li>
+</ol>
+<li><strong>Illustrative Metaphor:</strong> The process can be likened to a caterpillar entering a chrysalis to emerge as a butterfly. The caterpillar (child) must first separate itself, then undergoes a transformative, unstructured "liminal" phase in the chrysalis, before being reintegrated into the world in a new form (adult).</li>
+</ul>
+<h2>3. Historical & Cultural Context</h2>
+<ul>
+<li><strong>Key Traditions:</strong></li>
+<ul>
+<li><strong>Maasai (East Africa):</strong> The <em>Emurata</em> (circumcision) ceremony marks the transition from boy to <em>Moran</em> (warrior).</li>
+<li><strong>Okiek (Kenya):</strong> The <em>Tumdo</em> initiation involves both boys and girls in a period of seclusion and instruction in the forest.</li>
+<li><strong>Sateré-Mawé (Amazon):</strong> The Tucandeira ritual requires young men to repeatedly endure the stings of bullet ants woven into gloves.</li>
+<li><strong>Aboriginal Australians:</strong> Rites such as the <em>Bora</em> and solo journeys ("walkabouts") connect youths to the Dreaming and ancestral law through song, dance, and body modification.</li>
+<li><strong>Spartans (Ancient Greece):</strong> The <em>Agōgē</em> was a state-enforced educational and military training system that began at age seven.</li>
+<li><strong>Norse (Viking Age):</strong> Involved wilderness survival, symbolic transformation into animal-like warriors (berserkers), and enduring extreme elements to prove worthiness.</li>
+<li><strong>Celts (Iron Age Europe):</strong> Legendary trials, like those for the Fianna warriors in Ireland, tested skill, endurance, and intellect through ordeals such as defending oneself while buried to the waist.</li>
+</ul>
+<li><strong>Narrative Anecdotes:</strong></li>
+<ul>
+<li>A Maasai boy must endure circumcision without flinching to demonstrate his courage, with his mother celebrating his symbolic "rebirth" as a man.</li>
+<li>Okiek initiates are taught that a mythical beast roars in the forest at night, only to later be shown the bullroarer instrument that creates the sound, transforming their fear into secret knowledge.</li>
+<li>A Sateré-Mawé youth must dance for ten minutes while wearing gloves full of stinging bullet ants, an ordeal he will repeat up to 20 times over years.</li>
+<li>A Spartan boy was famously said to have hidden a stolen fox under his cloak, allowing it to gnaw him to death rather than cry out and reveal his theft and pain.</li>
+</ul>
+</ul>
+<h2>4. Psychological Functions</h2>
+<ul>
+<li><strong>Identity Formation:</strong> The rites provide a clear and dramatic break from a childhood identity and the conferral of a new, adult status. This is not a gradual process but a radical, memorable transformation, often described as a symbolic death and rebirth.</li>
+<li><strong>Resilience:</strong> The ordeal is central. By enduring pain, fear, or extreme hardship in a controlled, ritual context, the initiate learns they can withstand the inevitable suffering of life. This experience creates a psychological benchmark of strength and fortitude.</li>
+<li><strong>Belonging:</strong> The shared ordeal forges intense bonds among initiates, creating a strong sense of "communitas"—an egalitarian camaraderie that transcends previous social distinctions. Successful completion and reintegration solidifies their place as a valued member of the adult community.</li>
+<li><strong>Moral/Ethical Development:</strong> During the liminal phase, initiates are instructed in the sacred lore, laws, ethics, and values of their society. This ensures cultural continuity and imparts a sense of responsibility to uphold the community's traditions.</li>
+</ul>
+<h2>5. Modern Echoes</h2>
+<ul>
+<li><strong>Parallels Today:</strong> Military boot camps, fraternity/sorority hazing, grueling medical residencies, extreme sports, and some forms of therapy (like wilderness therapy for troubled youth) all contain elements of separation, ordeal, and reintegration.</li>
+<li><strong>Successes and Failures:</strong> Modern echoes often succeed in building resilience and group solidarity (e.g., a platoon of soldiers). However, they frequently lack the sacred or cosmological dimension of traditional rites, which connected the individual to ancestors, deities, and the land itself. Without this broader meaning, some modern "initiations" can devolve into mere hazing or tests of endurance with little lasting transformative power.</li>
+<li><strong>Implications:</strong> The decline of formal, meaningful rites of passage in many modern societies is linked by some psychologists to a prolonged adolescence and a lack of clear identity in young adults. There is a growing recognition of the need for structured transitions to help young people navigate the path to adulthood.</li>
+</ul>
+<h2>6. Key Themes & Insights</h2>
+<ul>
+<li><strong>Pain as a Teacher:</strong> Across these cultures, pain is not seen as something to be avoided, but as a crucible for forging character. It is a tool for transformation that teaches courage, discipline, and emotional control.</li>
+<li><strong>Symbolic Death and Rebirth:</strong> The initiate must "die" to their childhood self to be "reborn" as an adult. This is enacted through symbols of death (white clay, seclusion, darkness) and rebirth (new clothes, new names, celebratory feasts).</li>
+<li><strong>The Power of Secret Knowledge:</strong> Initiation grants access to knowledge previously forbidden. This secret lore—be it the nature of the "forest spirit" or the sacred songs of the ancestors—is a key marker of adult status and binds the initiated together.</li>
+</ul>
+<h2>7. Citations & Sources</h2>
+<ul>
+<li>(Eliade, 1958) Mircea Eliade, <em>Rites and Symbols of Initiation: The Mysteries of Birth and Rebirth</em>.</li>
+<li>(Turner, 1969) Victor Turner, <em>The Ritual Process: Structure and Anti-Structure</em>.</li>
+<li>(van Gennep, 1909) Arnold van Gennep, <em>Les Rites de Passage</em> (The Rites of Passage).</li>
+<li>Berndt, Ronald M., and Catherine H. Berndt. (1996). <em>The World of the First Australians</em>. Aboriginal Studies Press.</li>
+<li>Cartledge, Paul. (2004). <em>The Spartans: The World of the Warrior-Heroes of Ancient Greece</em>. Vintage Books.</li>
+<li>Kratz, Corinne A. (1994). <em>Affecting Performance: Meaning and Movement in Okiek Women's Initiation</em>. Smithsonian Institution Press.</li>
+<li>Mbiti, John S. (1970). <em>African Religions and Philosophy</em>. Heinemann.</li>
+<li>Ole Saitoti, Tepilit. (1986). <em>The Worlds of a Maasai Warrior</em>. University of California Press.</li>
+<li>Pontes, Marcos. (2018). "Tucandeira: Uma Tradição dos Sateré-Mawé." <em>Revista de Estudos Amazônicos</em>.</li>
+<li>Rolleston, T.W. (1911). <em>The Legends of the Celtic Race</em>.</li>
+<li>Sturluson, Snorri. (c. 1220). <em>Prose Edda</em>.</li>
+<li>Xenophon. <em>The Polity of the Lacedaemonians</em>.</li>
+</ul>
+</section>
 </body>
 </html>

--- a/research/research_htmls/Ep3.html
+++ b/research/research_htmls/Ep3.html
@@ -1,140 +1,89 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang='en'>
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Rites of Passage: Symbols &amp; Archetypes</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="ResearchGuideStyles.css">
+    <meta charset='UTF-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+    <title>Ep3 Research Brief</title>
+    <link rel='preconnect' href='https://fonts.googleapis.com'>
+    <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
+    <link href='https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Inter:wght@300;400;500;600&display=swap' rel='stylesheet'>
+    <link rel='stylesheet' href='ResearchGuideStyles.css'>
 </head>
 <body>
-    <section class="section-container">
-        <!-- Hero Summary Box -->
-        <div class="hero-summary-box">
-            <div class="research-brief-label">Research Brief</div>
-
-            <div class="episode-title-block">
-                <span class="episode-prefix">Episode 3:</span>
-                <h1 class="main-title">Symbols &amp; Archetypes</h1>
-            </div>
-            <p class="hero-tagline">Language of the Soul</p>
-
-            <div class="executive-summary">
-                <h2>Executive Summary</h2>
-                <p>This episode explores initiation rites as a fundamental human experience, marking the transition from one life stage to another through a process of symbolic death and rebirth. These rituals provide a structured framework for navigating profound personal change, fostering identity, resilience, and belonging. Understanding these ancient practices reveals a universal human need for meaningful transitions—a need often unmet in modern, secular societies, with significant impacts on individual and collective well-being.</p>
-            </div>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Core Concept / Framework</h2>
-            <p>The primary framework is Arnold van Gennep's tripartite model of rites of passage.</p>
-            <ul class="manifesto-text">
-                <li><strong>Separation:</strong> Detachment from previous status and environment.</li>
-                <li><strong>Transition (Liminality):</strong> The ambiguous "in-between" state where transformation occurs.</li>
-                <li><strong>Incorporation:</strong> Reintroduction to society with a new identity, acknowledged by the community.</li>
-                <li><strong>Example:</strong> A college graduation—caps and gowns mark separation; the ceremony is liminality; conferring degrees completes incorporation.</li>
-            </ul>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Historical &amp; Cultural Context</h2>
-            <div class="episodes-grid fade-in visible">
-                <div class="episode-card">
-                    <h3>Maasai Moran (East Africa)</h3>
-                    <p class="hook">Circumcision and a period of warrior life transmit indigenous knowledge and identity.</p>
-                </div>
-                <div class="episode-card">
-                    <h3>Spartan Agoge (Ancient Greece)</h3>
-                    <p class="hook">Boys trained from age seven in endurance, discipline, and loyalty to the state.</p>
-                </div>
-                <div class="episode-card">
-                    <h3>Native American Vision Quest</h3>
-                    <p class="hook">Solitary fasting and guidance from elders to receive a vision shaping adult roles.</p>
-                </div>
-            </div>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Psychological Functions</h2>
-            <div class="core-pillars-grid fade-in visible">
-                <div class="pillar-card">
-                    <h3>Identity Formation</h3>
-                    <p>Rituals mark the transition with communal recognition, solidifying a new sense of self.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>Resilience</h3>
-                    <p>Ordeals test and build strength, instilling competence for future adversity.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>Belonging</h3>
-                    <p>Shared experiences create "communitas," confirming one's role within the group.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>Moral/Ethical Development</h3>
-                    <p>Liminal instruction transmits sacred lore, laws, and values across generations.</p>
-                </div>
-            </div>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Modern Echoes</h2>
-            <ul class="manifesto-text">
-                <li><strong>Examples:</strong> Military boot camps, fraternity pledging, graduation ceremonies, and wilderness therapy programs.</li>
-                <li><strong>Successes &amp; Failures:</strong> These echoes foster belonging and mark transitions but often lack sacred or community-wide significance, contributing to prolonged adolescence and alienation.</li>
-            </ul>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Key Themes &amp; Insights</h2>
-            <div class="core-pillars-grid fade-in visible">
-                <div class="pillar-card">
-                    <h3>Death and Rebirth</h3>
-                    <p>Initiation enacts the symbolic death of the old self and birth of the new.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>The Liminal Space</h3>
-                    <p>Transformation occurs in a vulnerable, potent "in-between" state.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>The Hero's Journey</h3>
-                    <p>Joseph Campbell's monomyth mirrors initiation: separation, trials, and return.</p>
-                </div>
-            </div>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Citations &amp; Suggested Sources</h2>
-            <ul class="manifesto-text research-links">
-                <li>(Van Gennep, 1909)</li>
-                <li>(Turner, 1969)</li>
-                <li>(Campbell, 1949)</li>
-                <li>(Jung, 1959)</li>
-                <li>(Britannica, T. Editors of Encyclopaedia, 2023)</li>
-                <li>(New World Encyclopedia, 2023)</li>
-                <li>(Fiveable, 2023)</li>
-                <li>(Open Sky Wilderness Therapy, 2023)</li>
-                <li>(Great Transition Stories, 2023)</li>
-                <li>(Weichold et al., 2021)</li>
-                <li>(Quora, 2011)</li>
-                <li>(StudySmarter, 2023)</li>
-                <li>(Blue Labyrinths, 2015)</li>
-                <li>(The Horizon of Reason, 2021)</li>
-                <li>(FreedomGPT, 2023)</li>
-                <li>(Encyclopedia.com, 2019)</li>
-                <li>(Aithor, 2024)</li>
-                <li>(Sümer, 2018)</li>
-                <li>(The Imbali ArtBooks, 2023)</li>
-                <li>(UNESCO, 2018)</li>
-                <li>(Ancient Origins, 2021)</li>
-                <li>(Hobbs et al., 2021)</li>
-                <li>(EBSCO Information Services, 2023)</li>
-                <li>(Breakwell, 2021)</li>
-                <li>(Visit Natives, 2024)</li>
-                <li>(TikTok, 2024)</li>
-            </ul>
-        </div>
-    </section>
+<section class='section-container'>
+<h3># Research Brief – Initiation: The Archetype of Transformation</h3>
+<h2>1. Executive Summary</h2>
+<p>This episode explores initiation rites as a fundamental human experience, marking the transition from one life stage to another through a process of symbolic death and rebirth. The core psychological insight is that these rituals provide a structured framework for navigating profound personal change, fostering identity, resilience, and a sense of belonging. Understanding these ancient practices is crucial as it reveals a universal human need for meaningful transitions, a need that often goes unmet in modern, secular societies, impacting our collective and individual well-being.</p>
+<h2>2. Core Concept / Framework</h2>
+<p>The primary framework for understanding initiation is <strong>Arnold van Gennep's tripartite model of rites of passage</strong>.</p>
+<ul>
+<li><strong>Definition in plain language:</strong> Van Gennep identified that rites of passage universally consist of three distinct phases:</li>
+<ol>
+<li><strong>Separation:</strong> The individual is detached from their previous social status and familiar environment.</li>
+<li><strong>Transition (Liminality):</strong> This is the "in-between" stage where the individual is no longer their old self but has not yet fully transitioned to their new identity. It's a period of ambiguity and transformation.</li>
+<li><strong>Incorporation:</strong> The individual is reintroduced into society with a new status and identity, which is then acknowledged and celebrated by the community.</li>
+</ol>
+<li><strong>Short illustrative example or metaphor:</strong> A college graduation ceremony exemplifies this process. Students are first separated by wearing distinct caps and gowns. The ceremony itself is the liminal phase—they are no longer undergraduates but not yet graduates. Finally, the conferring of degrees incorporates them into the community of alumni, a new social status.</li>
+</ul>
+<h2>3. Historical & Cultural Context</h2>
+<p>Initiation rites are a global phenomenon, with diverse expressions across cultures:</p>
+<ul>
+<li><strong>Maasai Moran (East Africa):</strong> Young Maasai men undergo a series of rites, including circumcision and a period of living as warriors (<em>morani</em>), to transition from boyhood to adulthood. A significant rite of passage was the lion hunt, which tested their bravery and skill. These ceremonies are crucial for the transmission of indigenous knowledge and cultural identity.</li>
+<li><strong>Spartan Agoge (Ancient Greece):</strong> In ancient Sparta, boys were taken from their families at age seven to be trained as soldiers in the <em>agoge</em>. This brutal regimen was a prolonged initiation that tested their endurance, discipline, and loyalty to the state.</li>
+<li><strong>Native American Vision Quest:</strong> Many Native American cultures, particularly those of the Plains, have the vision quest as a rite of passage. An adolescent would go on a solitary journey, often fasting, to seek a vision that would guide their role in the community.</li>
+</ul>
+<h2>4. Psychological Functions</h2>
+<p>Initiation rites serve several key psychological functions:</p>
+<ul>
+<li><strong>Identity formation:</strong> These rituals provide a clear and communally recognized transition from one identity to another (e.g., child to adult). The ordeal helps to solidify a new sense of self.</li>
+<li><strong>Resilience:</strong> The challenges and ordeals inherent in many initiation rites, whether physical or psychological, are designed to test and build the initiate's strength and fortitude. Overcoming these hardships instills a sense of competence and the ability to handle future adversity.</li>
+<li><strong>Belonging:</strong> By undergoing a shared, often difficult, experience, initiates develop a strong bond with their peers, a concept anthropologist Victor Turner called "communitas." Successful completion of the rite affirms their place and new role within the community.</li>
+<li><strong>Moral/ethical development:</strong> During the liminal phase, initiates are often instructed in the sacred lore, laws, and values of their society. This ensures the transmission of cultural wisdom and moral codes to the next generation.</li>
+</ul>
+<h2>5. Modern Echoes</h2>
+<p>While traditional, elaborate rites of passage are less common in modern Western societies, their echoes can be seen in various forms:</p>
+<ul>
+<li><strong>Military boot camps:</strong> These are intense periods of separation, training (ordeal), and integration into a new identity as a soldier.</li>
+<li><strong>Fraternity and sorority pledging:</strong> These processes, despite potential for hazing, follow the classic three-part structure of a rite of passage.</li>
+<li><strong>Graduation ceremonies:</strong> As mentioned, these mark a significant life transition with clear symbolic rituals.</li>
+<li><strong>Wilderness therapy programs:</strong> These programs often use a "rite of passage" framework, involving separation from the familiar, challenges in nature, and a return with new coping skills.</li>
+</ul>
+<p>These modern echoes often succeed in creating a sense of belonging and marking a transition. However, they can fail when they lack a deeper, sacred, or community-wide significance, becoming more of a personal achievement than a societal integration. The absence of widely recognized and meaningful rites of passage in modern life can contribute to a prolonged adolescence and a sense of alienation for young people.</p>
+<h2>6. Key Themes & Insights</h2>
+<ul>
+<li><strong>Theme 1: Death and Rebirth:</strong> At the heart of initiation is the symbolic death of the old self and the birth of a new one. This is often enacted through rituals of separation and ordeals that push the initiate to their limits.</li>
+<li><strong>Theme 2: The Liminal Space:</strong> The "in-between" phase is a period of great potential and vulnerability. It's where transformation happens, outside the normal structures of society.</li>
+<li><strong>Theme 3: The Hero's Journey:</strong> Mythologist Joseph Campbell's concept of the monomyth, or the hero's journey, mirrors the structure of initiation rites: separation, initiation (trials), and return. This suggests a deep, archetypal pattern in our understanding of personal growth.</li>
+</ul>
+<h2>7. Citations & Sources</h2>
+<ul>
+<li>(Van Gennep, 1909)</li>
+<li>(Turner, 1969)</li>
+<li>(Campbell, 1949)</li>
+<li>(Jung, 1959)</li>
+<li>(Britannica, T. Editors of Encyclopaedia, 2023)</li>
+<li>(New World Encyclopedia, 2023)</li>
+<li>(Fiveable, 2023)</li>
+<li>(Open Sky Wilderness Therapy, 2023)</li>
+<li>(Great Transition Stories, 2023)</li>
+<li>(Weichold et al., 2021)</li>
+<li>(Quora, 2011)</li>
+<li>(StudySmarter, 2023)</li>
+<li>(Blue Labyrinths, 2015)</li>
+<li>(The Horizon of Reason, 2021)</li>
+<li>(FreedomGPT, 2023)</li>
+<li>(Encyclopedia.com, 2019)</li>
+<li>(Aithor, 2024)</li>
+<li>(Sümer, 2018)</li>
+<li>(The Imbali ArtBooks, 2023)</li>
+<li>(UNESCO, 2018)</li>
+<li>(Ancient Origins, 2021)</li>
+<li>(Hobbs et al., 2021)</li>
+<li>(EBSCO Information Services, 2023)</li>
+<li>(Breakwell, 2021)</li>
+<li>(Visit Natives, 2024)</li>
+<li>(TikTok, 2024)</li>
+</ul>
+</section>
 </body>
 </html>

--- a/research/research_htmls/Ep4.html
+++ b/research/research_htmls/Ep4.html
@@ -1,120 +1,67 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang='en'>
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Rites of Passage: Reintegration &amp; Service</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="ResearchGuideStyles.css">
+    <meta charset='UTF-8'>
+    <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+    <title>Ep4 Research Brief</title>
+    <link rel='preconnect' href='https://fonts.googleapis.com'>
+    <link rel='preconnect' href='https://fonts.gstatic.com' crossorigin>
+    <link href='https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Inter:wght@300;400;500;600&display=swap' rel='stylesheet'>
+    <link rel='stylesheet' href='ResearchGuideStyles.css'>
 </head>
 <body>
-    <section class="section-container">
-        <!-- Hero Summary Box -->
-        <div class="hero-summary-box">
-            <div class="research-brief-label">Research Brief</div>
-
-            <div class="episode-title-block">
-                <span class="episode-prefix">Episode 4:</span>
-                <h1 class="main-title">Reintegration &amp; Service</h1>
-            </div>
-            <p class="hero-tagline">Returning with Purpose</p>
-
-            <div class="executive-summary">
-                <h2>Executive Summary</h2>
-                <p>This episode examines how rites of passage use structured ordeals and ceremonies to guide the moral and psychological journey from childhood to adulthood. Drawing on theories from Lawrence Kohlberg, Jonathan Haidt, Jordan Peterson, and adolescent developmental psychology, it argues that challenging trials catalyze identity, resilience, and a mature moral compass. The decline of meaningful rites in modern society has left a developmental void, potentially contributing to prolonged adolescence and unhealthy searches for meaning.</p>
-            </div>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Core Concept / Framework</h2>
-            <ul class="manifesto-text">
-                <li><strong>Anchor Theory:</strong> Rites of Passage as a catalyst for moral maturation.</li>
-                <li><strong>Definition:</strong> Structured events marking transition through separation, ordeal, and communal reintegration.</li>
-                <li><strong>Metaphor:</strong> Like a blacksmith forging a blade—separation, fire, hammering, and cooling produce a tempered adult.</li>
-            </ul>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Historical &amp; Cultural Context</h2>
-            <div class="episodes-grid fade-in visible">
-                <div class="episode-card">
-                    <h3>Spartan Krypteia</h3>
-                    <p class="hook">Selected youth survive a year in the wilderness, enforcing Spartan law.</p>
-                </div>
-                <div class="episode-card">
-                    <h3>Aboriginal Walkabout</h3>
-                    <p class="hook">A 13-year-old navigates the outback alone using ancestral songlines.</p>
-                </div>
-                <div class="episode-card">
-                    <h3>Maasai Lion Hunt</h3>
-                    <p class="hook">Young men historically hunted lions to prove bravery and readiness to protect the community.</p>
-                </div>
-            </div>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Psychological Functions</h2>
-            <div class="core-pillars-grid fade-in visible">
-                <div class="pillar-card">
-                    <h3>Identity Formation</h3>
-                    <p>Rites answer "Who am I?" by testing and bestowing new adult roles, resolving Erikson's identity crisis.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>Resilience</h3>
-                    <p>Ordeal builds "earned confidence" through voluntary confrontation with hardship.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>Belonging</h3>
-                    <p>Communal trials activate loyalty and bind initiates to elders and tradition.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>Moral/Ethical Development</h3>
-                    <p>Challenges create cognitive conflict, advancing moral reasoning to duty and social order.</p>
-                </div>
-            </div>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Modern Echoes</h2>
-            <ul class="manifesto-text">
-                <li><strong>Parallels:</strong> Military boot camps, Outward Bound, martial arts tests, driver's licenses.</li>
-                <li><strong>Success &amp; Failure:</strong> Success requires genuine challenge, mentorship, and communal recognition; failure arises in hollow ceremonies or unstructured cruelty.</li>
-                <li><strong>Implications:</strong> Without positive rites, youth may seek risk and validation in maladaptive ways.</li>
-            </ul>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Key Themes &amp; Insights</h2>
-            <div class="core-pillars-grid fade-in visible">
-                <div class="pillar-card">
-                    <h3>Character is Forged, Not Given</h3>
-                    <p>Virtue and confidence arise from overcoming adversity.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>The Necessity of the Threshold</h3>
-                    <p>Adulthood requires crossing a challenging boundary.</p>
-                </div>
-                <div class="pillar-card">
-                    <h3>Biology Needs a Blueprint</h3>
-                    <p>Rites harness adolescent risk-taking and identity seeking for growth.</p>
-                </div>
-            </div>
-        </div>
-
-        <div class="subsection-container fade-in visible">
-            <h2 class="subsection-title">Citations &amp; Suggested Sources</h2>
-            <ul class="manifesto-text research-links">
-                <li>Kohlberg</li>
-                <li>Haidt</li>
-                <li>Peterson</li>
-                <li>Erikson</li>
-                <li>Spartan Agoge</li>
-                <li>Aboriginal Walkabout</li>
-                <li>Outward Bound</li>
-            </ul>
-        </div>
-    </section>
+<section class='section-container'>
+<h1>Research Brief – Rites of Passage & The Forging of Moral Adulthood</h1>
+<h2>1. Executive Summary</h2>
+<p>This episode explores how cultures throughout history have utilized "rites of passage"—structured ordeals and ceremonies—to guide the moral and psychological journey from childhood to adulthood. Modern psychology provides key frameworks for understanding why these rituals are so effective. Theories from Lawrence Kohlberg (moral reasoning), Jonathan Haidt (moral intuition), Jordan Peterson (earned confidence), and adolescent developmental psychology reveal that challenging trials are a necessary catalyst for developing identity, resilience, and a mature moral compass. This matters because the decline of meaningful rites of passage in contemporary society has left a developmental void, potentially contributing to prolonged adolescence and a search for meaning in unhealthy ways.</p>
+<hr/>
+<h2>2. Core Concept / Framework</h2>
+<ul>
+<li><strong>Anchor Theory:</strong> Rites of Passage as a Catalyst for Moral Maturation.</li>
+<li><strong>Definition in Plain Language:</strong> A rite of passage is a structured community event that marks a person's transition from one life stage to another, especially adolescence to adulthood. It uses a sequence of separation, a challenging trial (an "ordeal"), and communal reintegration to forge a new social and psychological identity. It’s a process of guided transformation through a meaningful challenge.</li>
+<li><strong>Short Illustrative Metaphor:</strong> A rite of passage is like a blacksmith forging a blade. An adolescent (the raw metal) is separated and thrust into the fire of a difficult ordeal, which makes them malleable. They are then hammered by challenges and shaped by cultural wisdom, and finally cooled and welcomed back into the community as a strong, tempered, and purposeful adult.</li>
+</ul>
+<hr/>
+<h2>3. Historical & Cultural Context</h2>
+<ul>
+<li><strong>Key traditions or societies that embody the concept:</strong> Ancient Sparta, Indigenous Australia, and various Native American tribes provide powerful examples of formalized ordeals.</li>
+<li><strong>Short narrative anecdotes (1–3 sentences each):</strong></li>
+<ul>
+<li><strong>Spartan Krypteia:</strong> A select 18-year-old youth was sent into the wilderness for a year, armed only with a dagger, forced to survive unseen and enforce Spartan law, forging a mindset of absolute duty and endurance.</li>
+<li><strong>Aboriginal Walkabout:</strong> A 13-year-old boy was sent alone into the outback for up to six months, using ancestral knowledge of "songlines" to navigate, hunt, and survive, returning with the earned self-confidence and spiritual identity of a man.</li>
+<li><strong>Maasai Lion Hunt:</strong> Historically, young Maasai men had to hunt a lion to prove their bravery and transition into warriorhood, demonstrating their readiness to protect the community.</li>
+</ul>
+</ul>
+<hr/>
+<h2>4. Psychological Functions</h2>
+<ul>
+<li><strong>Identity Formation:</strong> Rites of passage provide a clear, structured answer to the adolescent question, "Who am I?" by testing the individual and then bestowing a new, respected adult role and status within the community, resolving what psychologist Erik Erikson called the "Identity vs. Role Confusion" crisis.</li>
+<li><strong>Resilience:</strong> The ordeal serves as a crucible for what Jordan Peterson calls "earned confidence." By voluntarily confronting and overcoming a genuine hardship, the initiate gains tangible proof of their competence and fortitude, building an inner strength that cannot be given, only earned.</li>
+<li><strong>Belonging:</strong> Communal initiations activate what Jonathan Haidt calls the "Loyalty/ingroup" moral foundation. Surviving a trial together binds initiates to each other and reinforces their connection to the community's values, elders (Authority), and sacred traditions (Sanctity).</li>
+<li><strong>Moral/Ethical Development:</strong> According to Lawrence Kohlberg's model, ordeals create "cognitive conflict" that pushes an adolescent's moral reasoning from a self-interested (Pre-conventional) stage to one based on duty, law, and social order (Conventional). The initiate is forced to subordinate personal comfort for the sake of communal rules and ideals.</li>
+</ul>
+<hr/>
+<h2>5. Modern Echoes</h2>
+<ul>
+<li><strong>Parallels in today’s world:</strong> Positive echoes include military boot camps, wilderness programs like Outward Bound, rigorous martial arts belt tests, and earning a driver's license. Negative or distorted echoes can be seen in gang initiations, fraternity hazing, and dangerous social media challenges.</li>
+<li><strong>Where these echoes succeed or fail:</strong> They succeed when they contain a genuine, structured challenge, mentorship, and meaningful communal recognition (e.g., a Marine earning their Eagle, Globe, and Anchor). They fail when they are mere ceremonies without a true ordeal, or when they devolve into unstructured cruelty that lacks a guiding ethical framework.</li>
+<li><strong>Implications for adolescence/adulthood now:</strong> Without clearly defined, positive rites of passage, modern adolescents are often left to invent their own. This can lead them to seek risk and peer validation in maladaptive ways, fulfilling a deep psychological need through unhealthy means.</li>
+</ul>
+<hr/>
+<h2>6. Key Themes & Insights</h2>
+<ul>
+<li><strong>Theme 1: Character is Forged, Not Given.</strong> Virtue, confidence, and resilience are byproducts of overcoming adversity; they cannot be achieved through comfort or passive affirmation.</li>
+<li><strong>Theme 2: The Necessity of the Threshold.</strong> Moral and psychological adulthood is not an automatic function of age but a transformation that requires consciously crossing a challenging threshold.</li>
+<li><strong>Theme 3: Biology Needs a Blueprint.</strong> Adolescence is a neurobiologically primed period of risk-taking and identity-seeking. Rites of passage serve as the cultural blueprint to harness this energy for productive growth rather than destructive behavior.</li>
+</ul>
+<hr/>
+<h2>7. Citations & Sources</h2>
+<ul>
+<li>A synthesis of the ideas from: (Kohlberg), (Haidt), (Peterson), and (Erikson) as presented in the source document.</li>
+<li>Key historical examples: Spartan Agoge, Aboriginal Walkabout</li>
+<li>Modern parallels: Outward Bound as a secular rite of passage.</li>
+</ul>
+<hr/>
+</section>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Regenerate Ep1-Ep4 research HTMLs directly from their markdown briefs, excluding podcast takeaways
- Add lightweight converter script to rebuild HTML from markdown

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1d1c05e1c8323a3eec91c9013c94e